### PR TITLE
Set certain Python package dependencies to fixed versions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: init testnb test pylint
+all: init test-nb test pylint
 
 init:
 	pip install -r requirements.txt

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# Hotfix 2.0,1
+
+* Updates certain package versions in requirements.txt and setup.py to address
+  package dependency compatibility issues.
+
 # Release 2.0
 
 * Changes `create_tfrecords` and `check_tfrecords` to `convert` and `inspect` respectively

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,18 @@
-apache-beam[gcp] >= 2.22.0
+apache-beam[gcp] == 2.24.0
 pandas >= 1.0.4
-tensorflow_transform >= 0.22
+# TODO(cezequiel): Support breaking changes in TF Transform 0.25.0
+tensorflow_transform == 0.24.1
 Pillow >= 7.1.2
 coverage >= 5.1
 ipython >= 7.15.0
 nose >= 1.3.7
 numpy < 1.19.0
-pylint >= 2.5.3
+pylint == 2.6.0
 fire >= 0.3.1
 jupyter >= 1.0.0
-tensorflow >= 2.3.1
+tensorflow == 2.3.1
 pyarrow <0.18,>=0.17
-frozendict >= 1.2
+frozendict == 1.2
 dataclasses >= 0.5;python_version<"3.7"
 nbval >= 0.9.6
 pytest >= 6.1.1

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,15 @@ from setuptools import setup
 
 
 # Semantic versioning (PEP 440)
-VERSION = '2.0'
+VERSION = '2.0.1'
 
 REQUIRED_PACKAGES = [
-    "apache-beam[gcp] >= 2.22.0",
+    "apache-beam[gcp] == 2.24.0",
     "avro >= 1.10.0",
     "coverage >= 5.1",
     "ipython >= 7.15.0",
     "fire >= 0.3.1",
-    "frozendict >= 1.2",
+    "frozendict == 1.2",
     "nose >= 1.3.7",
     "numpy < 1.19.0",
     "pandas >= 1.0.4",
@@ -39,7 +39,7 @@ REQUIRED_PACKAGES = [
     "pytz >= 2020.1",
     "python-dateutil",
     "tensorflow == 2.3.1",
-    "tensorflow_transform >= 0.22",
+    "tensorflow_transform == 0.24.1",
 ]
 
 if sys.version_info < (3,7,0,0,0):


### PR DESCRIPTION
This is mainly to avoid compatibility issues with newer versions of other
packages (e.g. tensorflow-transform 0.25.0) that could be installed
using the '>=' specifier.

## Description

Please include the following:
- Please include a summary of the change and which issue is fixed. 
- Context/reason for change and issue # if applicable
- Any dependencies that are required for this change.

Fixes #68 (bandaid fix)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete options that are not relevant.

- [X] I ran `make pylint` and code is rated 10/10
- [X] I ran `make test` and all tests pass
- [X] My changes generate no new warnings
- [ ] I have corrected any misspellings in my code
- [X] (For hotfix/release) I have updated the package version number in `setup.py` (i.e. [MAJOR.MINOR.PATCH](https://semver.org/))
- [X] (For hotfix/release) I have updated RELEASE.md with notes regarding the changes
